### PR TITLE
Default address update and table creation statements

### DIFF
--- a/rogueserver.go
+++ b/rogueserver.go
@@ -34,7 +34,7 @@ func main() {
 	debug := flag.Bool("debug", false, "use debug mode")
 
 	proto := flag.String("proto", "tcp", "protocol for api to use (tcp, unix)")
-	addr := flag.String("addr", "0.0.0.0", "network address for api to listen on")
+	addr := flag.String("addr", "0.0.0.0:8001", "network address for api to listen on")
 
 	dbuser := flag.String("dbuser", "pokerogue", "database username")
 	dbpass := flag.String("dbpass", "", "database password")


### PR DESCRIPTION
1. Added `:8001` to the default address when starting the API server so that if the `-addr` argument isn't passed then the server still can start.
2. Added `create table if not exists` statements for the following tables: `accounts`, `accountStats`, `accountCompensations`, `dailyRuns`, `accountDailyRuns`, `dailyRunCompletions`, `sessions`.
3. Added creation of the `userdata` directory (if it doesn't exist) so that the server doesn't fail to start because it doesn't exist.