### PR TITLE
Added separate endpoints to handle eggs (get, update and delete)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ secret.key
 
 # local testing
 /.data/
+docker-compose.yml
 
 # Jetbrains IDEs
 /.idea/

--- a/api/common.go
+++ b/api/common.go
@@ -54,6 +54,9 @@ func Init(mux *http.ServeMux) error {
 	mux.HandleFunc("GET /savedata/delete", handleSaveData) // TODO use deleteSystemSave
 	mux.HandleFunc("POST /savedata/clear", handleSaveData) // TODO use clearSessionData
 	mux.HandleFunc("GET /savedata/newclear", handleNewClear)
+	mux.HandleFunc("GET /savedata/eggs", handleRetrieveEggs)
+	mux.HandleFunc("POST /savedata/eggs", handleUpdateEggs)
+	mux.HandleFunc("POST /savedata/deleteeggs", handleDeleteEgg)
 
 	// new session
 	mux.HandleFunc("POST /savedata/updateall", handleUpdateAll)

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -623,8 +623,8 @@ func handleRetrieveEggs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonResponse(w, r, eggs)
 	w.WriteHeader(http.StatusOK)
+	jsonResponse(w, r, eggs)
 }
 
 func handleUpdateEggs(w http.ResponseWriter, r *http.Request) {

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -624,7 +624,7 @@ func handleRetrieveEggs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonResponse(w, r, eggs)
-	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 }
 
 func handleUpdateEggs(w http.ResponseWriter, r *http.Request) {

--- a/db/db.go
+++ b/db/db.go
@@ -145,30 +145,114 @@ func Init(username, password, protocol, address, database string) error {
 
 func setupDb(tx *sql.Tx) error {
 	queries := []string{
-		`CREATE TABLE IF NOT EXISTS accounts (uuid BINARY(16) NOT NULL PRIMARY KEY, username VARCHAR(16) UNIQUE NOT NULL, hash BINARY(32) NOT NULL, salt BINARY(16) NOT NULL, registered TIMESTAMP NOT NULL, lastLoggedIn TIMESTAMP DEFAULT NULL, lastActivity TIMESTAMP DEFAULT NULL, banned TINYINT(1) NOT NULL DEFAULT 0, trainerId SMALLINT(5) UNSIGNED DEFAULT 0, secretId SMALLINT(5) UNSIGNED DEFAULT 0)`,
+		`CREATE TABLE IF NOT EXISTS accounts (
+				uuid BINARY(16) NOT NULL PRIMARY KEY, 
+				username VARCHAR(16) UNIQUE NOT NULL, 
+				hash BINARY(32) NOT NULL, 
+				salt BINARY(16) NOT NULL, 
+				registered TIMESTAMP NOT NULL, 
+				lastLoggedIn TIMESTAMP DEFAULT NULL, 
+				lastActivity TIMESTAMP DEFAULT NULL, 
+				banned TINYINT(1) NOT NULL DEFAULT 0, 
+				trainerId SMALLINT(5) UNSIGNED DEFAULT 0, 
+				secretId SMALLINT(5) UNSIGNED DEFAULT 0)`,
 		`CREATE INDEX IF NOT EXISTS accountsByActivity ON accounts (lastActivity)`,
 
-		`CREATE TABLE IF NOT EXISTS sessions (token BINARY(32) NOT NULL PRIMARY KEY, uuid BINARY(16) NOT NULL, active TINYINT(1) NOT NULL DEFAULT 0, expire TIMESTAMP DEFAULT NULL, CONSTRAINT sessions_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) ON DELETE CASCADE ON UPDATE CASCADE)`,
+		`CREATE TABLE IF NOT EXISTS sessions (
+				token BINARY(32) NOT NULL PRIMARY KEY, 
+				uuid BINARY(16) NOT NULL, 
+				active TINYINT(1) NOT NULL DEFAULT 0, 
+				expire TIMESTAMP DEFAULT NULL, 
+				CONSTRAINT sessions_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) 
+				ON DELETE CASCADE 
+				ON UPDATE CASCADE)`,
 		`CREATE INDEX IF NOT EXISTS sessionsByUuid ON sessions (uuid)`,
 
-		`CREATE TABLE IF NOT EXISTS accountStats (uuid BINARY(16) NOT NULL PRIMARY KEY, playTime INT(11) NOT NULL DEFAULT 0, battles INT(11) NOT NULL DEFAULT 0, classicSessionsPlayed INT(11) NOT NULL DEFAULT 0, sessionsWon INT(11) NOT NULL DEFAULT 0, highestEndlessWave INT(11) NOT NULL DEFAULT 0, highestLevel INT(11) NOT NULL DEFAULT 0, pokemonSeen INT(11) NOT NULL DEFAULT 0, pokemonDefeated INT(11) NOT NULL DEFAULT 0, pokemonCaught INT(11) NOT NULL DEFAULT 0, pokemonHatched INT(11) NOT NULL DEFAULT 0, eggsPulled INT(11) NOT NULL DEFAULT 0, regularVouchers INT(11) NOT NULL DEFAULT 0, plusVouchers INT(11) NOT NULL DEFAULT 0, premiumVouchers INT(11) NOT NULL DEFAULT 0, goldenVouchers INT(11) NOT NULL DEFAULT 0, CONSTRAINT accountStats_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) ON DELETE CASCADE ON UPDATE CASCADE)`,
+		`CREATE TABLE IF NOT EXISTS accountStats (
+				uuid BINARY(16) NOT NULL PRIMARY KEY, 
+				playTime INT(11) NOT NULL DEFAULT 0, 
+				battles INT(11) NOT NULL DEFAULT 0, 
+				classicSessionsPlayed INT(11) NOT NULL DEFAULT 0, 
+				sessionsWon INT(11) NOT NULL DEFAULT 0, 
+				highestEndlessWave INT(11) NOT NULL DEFAULT 0, 
+				highestLevel INT(11) NOT NULL DEFAULT 0, 
+				pokemonSeen INT(11) NOT NULL DEFAULT 0, 
+				pokemonDefeated INT(11) NOT NULL DEFAULT 0, 
+				pokemonCaught INT(11) NOT NULL DEFAULT 0, 
+				pokemonHatched INT(11) NOT NULL DEFAULT 0, 
+				eggsPulled INT(11) NOT NULL DEFAULT 0, 
+				regularVouchers INT(11) NOT NULL DEFAULT 0, 
+				plusVouchers INT(11) NOT NULL DEFAULT 0, 
+				premiumVouchers INT(11) NOT NULL DEFAULT 0, 
+				goldenVouchers INT(11) NOT NULL DEFAULT 0, 
+				CONSTRAINT accountStats_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) 
+				ON DELETE CASCADE 
+				ON UPDATE CASCADE)`,
 
-		`CREATE TABLE IF NOT EXISTS accountCompensations (id INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY, uuid BINARY(16) NOT NULL, voucherType INT(11) NOT NULL, count INT(11) NOT NULL DEFAULT 1, claimed BIT(1) NOT NULL DEFAULT b'0', CONSTRAINT accountCompensations_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) ON DELETE CASCADE ON UPDATE CASCADE)`,
+		`CREATE TABLE IF NOT EXISTS accountCompensations (
+				id INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY, 
+				uuid BINARY(16) NOT NULL, 
+				voucherType INT(11) NOT NULL, 
+				count INT(11) NOT NULL DEFAULT 1, 
+				claimed BIT(1) NOT NULL DEFAULT b'0', 
+				CONSTRAINT accountCompensations_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) 
+				ON DELETE CASCADE 
+				ON UPDATE CASCADE)`,
 		`CREATE INDEX IF NOT EXISTS accountCompensationsByUuid ON accountCompensations (uuid)`,
 
-		`CREATE TABLE IF NOT EXISTS dailyRuns (date DATE NOT NULL PRIMARY KEY, seed CHAR(24) CHARACTER SET ascii COLLATE ascii_bin NOT NULL)`,
+		`CREATE TABLE IF NOT EXISTS dailyRuns (
+				date DATE NOT NULL PRIMARY KEY, 
+				seed CHAR(24) CHARACTER SET ascii COLLATE ascii_bin NOT NULL)`,
 		`CREATE INDEX IF NOT EXISTS dailyRunsByDateAndSeed ON dailyRuns (date, seed)`,
 
-		`CREATE TABLE IF NOT EXISTS dailyRunCompletions (uuid BINARY(16) NOT NULL, seed CHAR(24) CHARACTER SET ascii COLLATE ascii_bin NOT NULL, mode INT(11) NOT NULL DEFAULT 0, score INT(11) NOT NULL DEFAULT 0, timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (uuid, seed), CONSTRAINT dailyRunCompletions_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) ON DELETE CASCADE ON UPDATE CASCADE)`,
+		`CREATE TABLE IF NOT EXISTS dailyRunCompletions (
+				uuid BINARY(16) NOT NULL, 
+				seed CHAR(24) CHARACTER SET ascii COLLATE ascii_bin NOT NULL, 
+				mode INT(11) NOT NULL DEFAULT 0, 
+				score INT(11) NOT NULL DEFAULT 0, 
+				timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+				PRIMARY KEY (uuid, seed), 
+				CONSTRAINT dailyRunCompletions_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) 
+				ON DELETE CASCADE 
+				ON UPDATE CASCADE)`,
 		`CREATE INDEX IF NOT EXISTS dailyRunCompletionsByUuidAndSeed ON dailyRunCompletions (uuid, seed)`,
 
-		`CREATE TABLE IF NOT EXISTS accountDailyRuns (uuid BINARY(16) NOT NULL, date DATE NOT NULL, score INT(11) NOT NULL DEFAULT 0, wave INT(11) NOT NULL DEFAULT 0, timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (uuid, date), CONSTRAINT accountDailyRuns_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) ON DELETE CASCADE ON UPDATE CASCADE, CONSTRAINT accountDailyRuns_ibfk_2 FOREIGN KEY (date) REFERENCES dailyRuns (date) ON DELETE NO ACTION ON UPDATE NO ACTION)`,
+		`CREATE TABLE IF NOT EXISTS accountDailyRuns (
+				uuid BINARY(16) NOT NULL, 
+				date DATE NOT NULL, 
+				score INT(11) NOT NULL DEFAULT 0, 
+				wave INT(11) NOT NULL DEFAULT 0, 
+				timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+				PRIMARY KEY (uuid, date), 
+				CONSTRAINT accountDailyRuns_ibfk_1 FOREIGN KEY (uuid) REFERENCES accounts (uuid) 
+				ON DELETE CASCADE 
+				ON UPDATE CASCADE, 
+				CONSTRAINT accountDailyRuns_ibfk_2 FOREIGN KEY (date) REFERENCES dailyRuns (date) 
+				ON DELETE NO ACTION 
+				ON UPDATE NO ACTION)`,
 		`CREATE INDEX IF NOT EXISTS accountDailyRunsByDate ON accountDailyRuns (date)`,
 
-		`CREATE TABLE IF NOT EXISTS systemSaveData (uuid BINARY(16) PRIMARY KEY, data LONGBLOB, timestamp TIMESTAMP)`,
+		`CREATE TABLE IF NOT EXISTS systemSaveData (
+				uuid BINARY(16) PRIMARY KEY, 
+				data LONGBLOB, 
+				timestamp TIMESTAMP)`,
 
-		`CREATE TABLE IF NOT EXISTS sessionSaveData (uuid BINARY(16), slot TINYINT, data LONGBLOB, timestamp TIMESTAMP, PRIMARY KEY (uuid, slot))`,
-	}
+		`CREATE TABLE IF NOT EXISTS sessionSaveData (
+				uuid BINARY(16), 
+				slot TINYINT, 
+				data LONGBLOB, 
+				timestamp TIMESTAMP, 
+				PRIMARY KEY (uuid, slot))`,
+
+		`CREATE TABLE IF NOT EXISTS eggs (
+				uuid VARCHAR(32) NOT NULL PRIMARY KEY,
+				owner BINARY(16) NOT NULL,
+				gachaType INT(11) NOT NULL,
+				hatchWaves INT(11) NOT NULL,
+				timestamp INT NOT NULL,
+				CONSTRAINT eggs_ibfk_1 FOREIGN KEY (owner) REFERENCES accounts (uuid)
+				ON DELETE CASCADE 
+				ON UPDATE CASCADE)`}
 
 	for _, q := range queries {
 		_, err := tx.Exec(q)

--- a/db/savedata.go
+++ b/db/savedata.go
@@ -173,12 +173,6 @@ func UpdateAccountEggs(uuid []byte, eggs []defs.EggData) error {
 			continue
 		}
 
-		var buf bytes.Buffer
-		err := gob.NewEncoder(&buf).Encode(egg)
-		if err != nil {
-			return err
-		}
-
 		_, err = handle.Exec(`INSERT INTO eggs (uuid, owner, gachaType, hatchWaves, timestamp) 
 							  VALUES (?, ?, ?, ?, ?) 
 							  ON DUPLICATE KEY UPDATE hatchWaves = ?`, 

--- a/db/savedata.go
+++ b/db/savedata.go
@@ -170,7 +170,9 @@ func UpdateAccountEggs(uuid []byte, eggs []defs.EggData) error {
 	if err != nil {
 		return err
 	}
-defer tx.Rollback()
+
+	defer tx.Rollback()
+	
 	for _, egg := range eggs {
 		// TODO: find a fix to enforce encoding from body to EggData only if
 		// it respects the EggData struct so we can get rid of the test 

--- a/db/savedata.go
+++ b/db/savedata.go
@@ -170,7 +170,7 @@ func UpdateAccountEggs(uuid []byte, eggs []defs.EggData) error {
 	if err != nil {
 		return err
 	}
-
+defer tx.Rollback()
 	for _, egg := range eggs {
 		// TODO: find a fix to enforce encoding from body to EggData only if
 		// it respects the EggData struct so we can get rid of the test 


### PR DESCRIPTION
As discussed on discord, creating the endpoints on the backend to separate save request.

Only the enpoints for the eggs on this PR is implemented:
`GET /savedata/eggs` to retrieve list of the eggs an account has 
`POST /savedata/eggs` to update the eggs values
`POST /savedata/deleteeggs` to delete eggs

With those endpoints and the handlers, there's a new table "eggs"

Here's the tests I made, you can replicate by changing the token to an account on your instance:
![image](https://github.com/pagefaultgames/rogueserver/assets/52253862/b34f418d-3132-435e-893d-0bcb2250ea9b)
