### PR TITLE
Added back-end support for friends

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -44,6 +44,7 @@ func Init(mux *http.ServeMux) error {
 	mux.HandleFunc("GET /account/logout", handleAccountLogout)
 	mux.HandleFunc("POST /account/addfriend", handleAddFriend)
 	mux.HandleFunc("POST /account/removefriend", handleRemoveFriend)
+	mux.HandleFunc("GET /account/friendsonline", handleFriendsOnlineStat)
 
 	// game
 	mux.HandleFunc("GET /game/titlestats", handleGameTitleStats)

--- a/api/common.go
+++ b/api/common.go
@@ -43,6 +43,7 @@ func Init(mux *http.ServeMux) error {
 	mux.HandleFunc("POST /account/changepw", handleAccountChangePW)
 	mux.HandleFunc("GET /account/logout", handleAccountLogout)
 	mux.HandleFunc("POST /account/addfriend", handleAddFriend)
+	mux.HandleFunc("POST /account/removefriend", handleRemoveFriend)
 
 	// game
 	mux.HandleFunc("GET /game/titlestats", handleGameTitleStats)

--- a/api/common.go
+++ b/api/common.go
@@ -42,6 +42,7 @@ func Init(mux *http.ServeMux) error {
 	mux.HandleFunc("POST /account/login", handleAccountLogin)
 	mux.HandleFunc("POST /account/changepw", handleAccountChangePW)
 	mux.HandleFunc("GET /account/logout", handleAccountLogout)
+	mux.HandleFunc("POST /account/addfriend", handleAddFriend)
 
 	// game
 	mux.HandleFunc("GET /game/titlestats", handleGameTitleStats)

--- a/api/daily/rankings.go
+++ b/api/daily/rankings.go
@@ -25,8 +25,8 @@ import (
 )
 
 // /daily/rankings - fetch daily rankings
-func Rankings(category, page int) ([]defs.DailyRanking, error) {
-	rankings, err := db.FetchRankings(category, page)
+func Rankings(category, page int, uuid []byte) ([]defs.DailyRanking, error) {
+	rankings, err := db.FetchRankings(category, page, uuid)
 	if err != nil {
 		log.Print("failed to retrieve rankings")
 	}

--- a/api/daily/rankingspagecount.go
+++ b/api/daily/rankingspagecount.go
@@ -24,8 +24,8 @@ import (
 )
 
 // /daily/rankingpagecount - fetch daily ranking page count
-func RankingPageCount(category int) (int, error) {
-	pageCount, err := db.FetchRankingPageCount(category)
+func RankingPageCount(category int, uuid []byte) (int, error) {
+	pageCount, err := db.FetchRankingPageCount(category, uuid)
 	if err != nil {
 		log.Print("failed to retrieve ranking page count")
 	}

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -145,10 +145,15 @@ func handleAddFriend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response, err := db.AddFriend(uuid, r.Form.Get("username"))
-	if err != nil {
-		httpError(w, r, err, http.StatusInternalServerError)
-		return
+	success, err := db.AddFriend(uuid, r.Form.Get("username"))
+	message := "Success"
+	if !success {
+		message = err.Error()
+	}
+
+	response := defs.GenericResponse{
+		Success: success,
+		Message: message,
 	}
 
 	jsonResponse(w, r, response)

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -186,6 +186,34 @@ func handleRemoveFriend(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, r, response)
 }
 
+func handleFriendsOnlineStat(w http.ResponseWriter, r *http.Request) {
+	uuid, err := uuidFromRequest(r)
+	if err != nil {
+		httpError(w, r, err, http.StatusBadRequest)
+		return
+	}
+
+	friendsAmount, countErr := db.FriendCount(uuid)
+	if countErr != nil {
+		httpError(w, r, countErr, http.StatusInternalServerError)
+		return
+	}
+
+	friendsOnline, onlineErr := db.FriendOnlineCount(uuid)
+	if onlineErr != nil {
+		httpError(w, r, onlineErr, http.StatusInternalServerError)
+		return
+	}
+
+	stats := defs.FriendsOnlineStats{
+		FriendsOnline: friendsOnline,
+		FriendsAmount: friendsAmount,
+	}
+
+	jsonResponse(w, r, stats)
+}
+
+
 // game
 func handleGameTitleStats(w http.ResponseWriter, r *http.Request) {
 	stats := defs.TitleStats{

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -159,6 +159,33 @@ func handleAddFriend(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, r, response)
 }
 
+func handleRemoveFriend(w http.ResponseWriter, r *http.Request) {
+	formErr := r.ParseForm()
+	if formErr != nil {
+		httpError(w, r, fmt.Errorf("failed to parse request form: %s", formErr), http.StatusBadRequest)
+		return
+	}
+
+	uuid, err := uuidFromRequest(r)
+	if err != nil {
+		httpError(w, r, err, http.StatusBadRequest)
+		return
+	}
+
+	success, err := db.RemoveFriend(uuid, r.Form.Get("username"))
+	message := "Success"
+	if !success {
+		message = err.Error()
+	}
+
+	response := defs.GenericResponse{
+		Success: success,
+		Message: message,
+	}
+
+	jsonResponse(w, r, response)
+}
+
 // game
 func handleGameTitleStats(w http.ResponseWriter, r *http.Request) {
 	stats := defs.TitleStats{

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -860,7 +860,11 @@ func handleDailySeed(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleDailyRankings(w http.ResponseWriter, r *http.Request) {
-	var err error
+	uuid, err := uuidFromRequest(r)
+	if err != nil {
+		httpError(w, r, err, http.StatusBadRequest)
+		return
+	}
 
 	var category int
 	if r.URL.Query().Has("category") {
@@ -880,7 +884,7 @@ func handleDailyRankings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	rankings, err := daily.Rankings(category, page)
+	rankings, err := daily.Rankings(category, page, uuid)
 	if err != nil {
 		httpError(w, r, err, http.StatusInternalServerError)
 		return
@@ -890,6 +894,12 @@ func handleDailyRankings(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleDailyRankingPageCount(w http.ResponseWriter, r *http.Request) {
+	uuid, err := uuidFromRequest(r)
+	if err != nil {
+		httpError(w, r, err, http.StatusBadRequest)
+		return
+	}
+
 	var category int
 	if r.URL.Query().Has("category") {
 		var err error
@@ -900,7 +910,7 @@ func handleDailyRankingPageCount(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	count, err := daily.RankingPageCount(category)
+	count, err := daily.RankingPageCount(category, uuid)
 	if err != nil {
 		httpError(w, r, err, http.StatusInternalServerError)
 	}

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -132,6 +132,28 @@ func handleAccountLogout(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func handleAddFriend(w http.ResponseWriter, r *http.Request) {
+	formErr := r.ParseForm()
+	if formErr != nil {
+		httpError(w, r, fmt.Errorf("failed to parse request form: %s", formErr), http.StatusBadRequest)
+		return
+	}
+
+	uuid, err := uuidFromRequest(r)
+	if err != nil {
+		httpError(w, r, err, http.StatusBadRequest)
+		return
+	}
+
+	response, err := db.AddFriend(uuid, r.Form.Get("username"))
+	if err != nil {
+		httpError(w, r, err, http.StatusInternalServerError)
+		return
+	}
+
+	jsonResponse(w, r, response)
+}
+
 // game
 func handleGameTitleStats(w http.ResponseWriter, r *http.Request) {
 	stats := defs.TitleStats{

--- a/db/account.go
+++ b/db/account.go
@@ -324,3 +324,39 @@ func RemoveFriend(uuid []byte, friendUsername string) (bool, error) {
 
 	return true, nil
 }
+
+func FriendCount(uuid []byte) (int, error) {
+	username, err := FetchUsernameFromUUID(uuid);
+	if err != nil {
+		return -1, err
+	}
+
+	var count int
+	err = handle.QueryRow("SELECT COUNT(*) FROM friends WHERE user = ?", username).Scan(&count)
+	if err != nil {
+		return -1, err
+	}
+
+	return count, nil
+}
+
+func FriendOnlineCount(uuid []byte) (int, error) {
+	username, err := FetchUsernameFromUUID(uuid);
+	if err != nil {
+		return -1, err
+	}
+	    
+	query := `SELECT COUNT(*) FROM accounts a
+  			  JOIN friends f
+  			  ON a.username = f.friend
+			  WHERE a.lastActivity > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 5 MINUTE)
+			  AND f.user = ?;`
+
+	var count int
+	err = handle.QueryRow(query, username).Scan(&count)
+	if err != nil {
+		return -1, err
+	}
+
+	return count, nil
+}

--- a/db/account.go
+++ b/db/account.go
@@ -276,15 +276,16 @@ func isFriendWith(sourceUsername string, friendUsername string) (bool, error) {
 }
 
 func AddFriend(uuid []byte, friendUsername string) (bool, error) {
+	// We are making db errors more generic as error is used in the response data to the client.
 	username, err := FetchUsernameFromUUID(uuid);
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("An error occured, are you connected ?")
 	}
 
 	var doesUserExist int
 	err = handle.QueryRow("SELECT COUNT(*) FROM accounts WHERE username = ?", friendUsername).Scan(&doesUserExist)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("An error occured, if this persist, please contact an administrators.")
 	}
 
 	if doesUserExist == 0 {

--- a/db/daily.go
+++ b/db/daily.go
@@ -19,6 +19,7 @@ package db
 
 import (
 	"math"
+	"database/sql"
 
 	"github.com/pagefaultgames/rogueserver/defs"
 )
@@ -53,8 +54,13 @@ func AddOrUpdateAccountDailyRun(uuid []byte, score int, wave int) error {
 	return nil
 }
 
-func FetchRankings(category int, page int) ([]defs.DailyRanking, error) {
+func FetchRankings(category int, page int, uuid []byte) ([]defs.DailyRanking, error) {
 	var rankings []defs.DailyRanking
+
+	username, err := FetchUsernameFromUUID(uuid);
+	if err != nil {
+		return rankings, err
+	}
 
 	offset := (page - 1) * 10
 
@@ -64,9 +70,36 @@ func FetchRankings(category int, page int) ([]defs.DailyRanking, error) {
 		query = "SELECT RANK() OVER (ORDER BY adr.score DESC, adr.timestamp), a.username, adr.score, adr.wave FROM accountDailyRuns adr JOIN dailyRuns dr ON dr.date = adr.date JOIN accounts a ON adr.uuid = a.uuid WHERE dr.date = UTC_DATE() AND a.banned = 0 LIMIT 10 OFFSET ?"
 	case 1:
 		query = "SELECT RANK() OVER (ORDER BY SUM(adr.score) DESC, adr.timestamp), a.username, SUM(adr.score), 0 FROM accountDailyRuns adr JOIN dailyRuns dr ON dr.date = adr.date JOIN accounts a ON adr.uuid = a.uuid WHERE dr.date >= DATE_SUB(DATE(UTC_TIMESTAMP()), INTERVAL DAYOFWEEK(UTC_TIMESTAMP()) - 1 DAY) AND a.banned = 0 GROUP BY a.username ORDER BY 1 LIMIT 10 OFFSET ?"
+	case 2:
+		// We retrieve the friends of the user and the user itself
+		query = `SELECT RANK() OVER (ORDER BY score DESC, timestamp) AS rank, username, score, wave
+				FROM (
+					SELECT a.username, adr.score, adr.wave, adr.timestamp
+					FROM accountDailyRuns adr
+					JOIN dailyRuns dr ON dr.date = adr.date
+					JOIN accounts a ON adr.uuid = a.uuid
+					JOIN friends f ON a.username = f.friend
+					WHERE dr.date = UTC_DATE()
+					AND a.banned = 0
+					AND f.user = ?
+					UNION
+					SELECT a.username, adr.score, adr.wave, adr.timestamp
+					FROM accountDailyRuns adr
+					JOIN dailyRuns dr ON dr.date = adr.date
+					JOIN accounts a ON adr.uuid = a.uuid
+					WHERE dr.date = UTC_DATE()
+					AND a.banned = 0
+					AND a.username = ?
+				) AS combined LIMIT 10 OFFSET ?;`
 	}
 
-	results, err := handle.Query(query, offset)
+	var results *sql.Rows
+	if category == 2 {
+		results, err = handle.Query(query, username, username, offset)
+	} else {
+		results, err = handle.Query(query, offset)
+	}
+
 	if err != nil {
 		return rankings, err
 	}
@@ -86,19 +119,37 @@ func FetchRankings(category int, page int) ([]defs.DailyRanking, error) {
 	return rankings, nil
 }
 
-func FetchRankingPageCount(category int) (int, error) {
+func FetchRankingPageCount(category int, uuid []byte) (int, error) {
+	username, err := FetchUsernameFromUUID(uuid);
+	if err != nil {
+		return 0, err
+	}
+
 	var query string
 	switch category {
 	case 0:
 		query = "SELECT COUNT(a.username) FROM accountDailyRuns adr JOIN dailyRuns dr ON dr.date = adr.date JOIN accounts a ON adr.uuid = a.uuid WHERE dr.date = UTC_DATE()"
 	case 1:
 		query = "SELECT COUNT(DISTINCT a.username) FROM accountDailyRuns adr JOIN dailyRuns dr ON dr.date = adr.date JOIN accounts a ON adr.uuid = a.uuid WHERE dr.date >= DATE_SUB(DATE(UTC_TIMESTAMP()), INTERVAL DAYOFWEEK(UTC_TIMESTAMP()) - 1 DAY)"
+	case 2:
+		query = `SELECT COUNT(a.username)
+				 FROM accountDailyRuns adr
+				 JOIN dailyRuns dr ON dr.date = adr.date
+				 JOIN accounts a ON adr.uuid = a.uuid
+				 JOIN friends f ON a.username = f.friend
+				 WHERE dr.date = UTC_DATE()
+				 AND f.user = ?
+				 OR a.username = ?`
 	}
 
 	var recordCount int
-	err := handle.QueryRow(query).Scan(&recordCount)
-	if err != nil {
-		return 0, err
+	if category == 2 {	
+		err = handle.QueryRow(query, username, username).Scan(&recordCount)
+		// We only fetch friends of the account, not the account itself so adding +1 here.
+		// this way, we don't have to do the big union query like in FetchRankings
+		recordCount += 1 
+	} else {
+		err = handle.QueryRow(query).Scan(&recordCount)
 	}
 
 	return int(math.Ceil(float64(recordCount) / 10)), nil

--- a/db/db.go
+++ b/db/db.go
@@ -176,6 +176,15 @@ func setupDb(tx *sql.Tx) error {
 
 		`ALTER TABLE sessions DROP COLUMN IF EXISTS active`,
 		`CREATE TABLE IF NOT EXISTS activeClientSessions (uuid BINARY(16) NOT NULL PRIMARY KEY, clientSessionId VARCHAR(32) NOT NULL, FOREIGN KEY (uuid) REFERENCES accounts (uuid) ON DELETE CASCADE ON UPDATE CASCADE)`,
+	
+		`CREATE TABLE IF NOT EXISTS friends (
+			relationId INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+			user VARCHAR(16) NOT NULL,
+			friend VARCHAR(16) NOT NULL,
+			since DATE NOT NULL,
+			FOREIGN KEY (user) REFERENCES accounts (username) ON DELETE CASCADE ON UPDATE CASCADE,
+			FOREIGN KEY (friend) REFERENCES accounts (username) ON DELETE CASCADE ON UPDATE CASCADE
+		)`,
 	}
 
 	for _, q := range queries {

--- a/defs/common.go
+++ b/defs/common.go
@@ -1,0 +1,23 @@
+/*
+	Copyright (C) 2024  Pagefault Games
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package defs
+
+type GenericResponse struct {
+	Success     bool    `json:"success"`
+	Message     string  `json:"message"`
+}

--- a/defs/game.go
+++ b/defs/game.go
@@ -21,3 +21,8 @@ type TitleStats struct {
 	PlayerCount int `json:"playerCount"`
 	BattleCount int `json:"battleCount"`
 }
+
+type FriendsOnlineStats struct {
+	FriendsOnline int `json:"friendsOnline"`
+	FriendsAmount int `json:"friendsAmount"`
+}


### PR DESCRIPTION
This has been discussed on discord with benny, this is the base work for friends. For now, we can add/remove friends and see them in the new daily friend ranking that will be implemented on front-end after this goes through. 

In order to make this work, I added a new table 'friends' that links usernames to show friend relations.

There's 3 new endpoints, `/account/addfriend`, `/account/removefriend`, `/account/friendsonline`, and a new category for the rankings.

Here's the tests I made:
#### adding/removing friends
![image](https://github.com/pagefaultgames/rogueserver/assets/52253862/7efedfc6-e1f6-4399-92bc-947a9d640842)

#### checking friends online
![image](https://github.com/pagefaultgames/rogueserver/assets/52253862/0b1aa5fd-9c7f-4ba0-a4f7-8bd19a4cf207)

#### comparing friend ranking and standard daily ranking
![image](https://github.com/pagefaultgames/rogueserver/assets/52253862/08f93f1d-286c-490c-ba7b-bc1fa1c52ee2)

Ideally, this could be merged before #13 as there's no merge conflict right now, and we need to wait for the backend to be ready before changing stuff on the front-end to implement it, so the sooner the better.