### PR TITLE
Add token version to session save data

### DIFF
--- a/defs/savedata.go
+++ b/defs/savedata.go
@@ -107,6 +107,7 @@ type SessionSaveData struct {
 	Trainer        TrainerData              `json:"trainer"`
 	GameVersion    string                   `json:"gameVersion"`
 	Timestamp      int                      `json:"timestamp"`
+	TokenVersion   int                      `json:"tokenVersion"`
 }
 
 type GameMode int


### PR DESCRIPTION
For pagefaultgames/pokerogue#1733
Adds a new field in the session save data to track token “versions” so the client knows when to update tokens
