### PR TITLE
Add ChallengeData to SessionSaveData

### DIFF
--- a/defs/savedata.go
+++ b/defs/savedata.go
@@ -107,6 +107,13 @@ type SessionSaveData struct {
 	Trainer        TrainerData              `json:"trainer"`
 	GameVersion    string                   `json:"gameVersion"`
 	Timestamp      int                      `json:"timestamp"`
+	Challenges     []ChallengeData          `json:"challenges"`
+}
+
+type ChallengeData struct {
+	Id       int `json:"id"`
+	Value    int `json:"value"`
+	Severity int `json:"severity"`
 }
 
 type GameMode int


### PR DESCRIPTION
This commit adds the `ChallengeData` struct to the `SessionSaveData` struct. The `ChallengeData` struct includes fields for `id`, `value`, and `severity`. This change allows for storing challenge data in the session save data.

This is linked to https://github.com/pagefaultgames/pokerogue/pull/1459/files