### PR TITLE
Updating instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker build . -t rogueserver
 The docker compose file should automatically implement a container with mariadb with an empty database and the default user and password combo of pokerogue:pokerogue
 
 ### .env and .env.development (in pokerogue)
-Replace both URLs (one on each line) with the local API server address from rogueserver.go (0.0.0.0:8001) (or whatever port you picked)
+Replace the URL on VITE_SERVER_URL in both files to match your local ip and port of rogueserver if nessessary
 
 # If you are on Windows
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ There is a sample docker-compose file for setting up a docker container to setup
 - npm: [how to install](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 
 ## Installation:
+```
+docker build . -t rogueserver
+```
+
 The docker compose file should automatically implement a container with mariadb with an empty database and the default user and password combo of pokerogue:pokerogue
 
-### src/utils.ts:224-225 (in pokerogue)
+### .env and .env.development (in pokerogue)
 Replace both URLs (one on each line) with the local API server address from rogueserver.go (0.0.0.0:8001) (or whatever port you picked)
 
 # If you are on Windows

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ There is a sample docker-compose file for setting up a docker container to setup
 ## Installation:
 ```
 docker build . -t rogueserver
+docker compose -f docker.compose.Example.yml up -d
 ```
 
 The docker compose file should automatically implement a container with mariadb with an empty database and the default user and password combo of pokerogue:pokerogue

--- a/docker-compose.Example.yml
+++ b/docker-compose.Example.yml
@@ -1,7 +1,7 @@
 services:
   server:
     command: --debug --dbaddr db --dbuser pokerogue --dbpass pokerogue --dbname pokeroguedb
-    image: ghcr.io/pagefaultgames/rogueserver:master
+    image: rogueserver:latest
     restart: unless-stopped
     depends_on:
       db:


### PR DESCRIPTION
## What are the changes?
Updated readme to make it more obvious you currently need to built the image locally, with instructions on how to do so
modified docker.compose.Example.yml to start rogueserver from local image
 
 ## Why am I doing these changes?
Instructions for running the server have changed recently from requiring modifications in src/utils.ts on pokerogue, to only needing to change environment variables. 
 
 ## What did change?
README.md
docker.compose.Example.yml