### PR TITLE
[Dev] Remove Version Checking

### DIFF
--- a/api/savedata/system.go
+++ b/api/savedata/system.go
@@ -21,10 +21,6 @@ func UpdateSystem(uuid []byte, data defs.SystemSaveData) error {
 		return fmt.Errorf("invalid system data")
 	}
 
-	if data.GameVersion != "1.0.4" {
-		return fmt.Errorf("client version out of date")
-	}
-
 	err := db.UpdateAccountStats(uuid, data.GameStats, data.VoucherCounts)
 	if err != nil {
 		return fmt.Errorf("failed to update account stats: %s", err)

--- a/api/savedata/update.go
+++ b/api/savedata/update.go
@@ -38,10 +38,6 @@ func Update(uuid []byte, slot int, save any) error {
 			return fmt.Errorf("invalid system data")
 		}
 
-		if save.GameVersion != "1.0.4" {
-			return fmt.Errorf("client version out of date")
-		}
-
 		err = db.UpdateAccountStats(uuid, save.GameStats, save.VoucherCounts)
 		if err != nil {
 			return fmt.Errorf("failed to update account stats: %s", err)


### PR DESCRIPTION
### Backend companion PR to pagefaultgames/pokerogue#4388

This removes the explicit version checking done in the backend that would normally require cause saves with a version not equal to `1.0.4` to force a reload on the frontend. Now that version migration is compartmentalized and complete, the `OutdatedPhase` that gets pushed is no longer needed, which also means the backend no longer needs to throw an error as well due to the changes made in the frontend companion PR.

