### PR TITLE
Made changes to server to allow admin panel to retrieve last activity instead of last logged in date

### DIFF
--- a/db/account.go
+++ b/db/account.go
@@ -208,20 +208,20 @@ type AdminSearchResponse struct {
 }
 
 func FetchAdminDetailsByUsername(dbUsername string) (AdminSearchResponse, error) {
-	var resultUsername, resultDiscordId, resultGoogleId, resultLastActivity, resultRegistered sql.NullString
+	var username, discordId, googleId, lastActivity, registered sql.NullString
 	var adminResponse AdminSearchResponse
 
-	err := handle.QueryRow("SELECT username, discordId, googleId, lastActivity, registered from accounts WHERE username = ?", dbUsername).Scan(&resultUsername, &resultDiscordId, &resultGoogleId, &resultLastActivity, &resultRegistered)
+	err := handle.QueryRow("SELECT username, discordId, googleId, lastActivity, registered from accounts WHERE username = ?", dbUsername).Scan(&username, &discordId, &googleId, &lastActivity, &registered)
 	if err != nil {
 		return adminResponse, err
 	}
 
 	adminResponse = AdminSearchResponse{
-		Username:        resultUsername.String,
-		DiscordId:       resultDiscordId.String,
-		GoogleId:        resultGoogleId.String,
-		LastActivity:    resultLastActivity.String,
-		Registered:		 resultRegistered.String,
+		Username:        username.String,
+		DiscordId:       discordId.String,
+		GoogleId:        googleId.String,
+		LastActivity:    lastActivity.String,
+		Registered:		 registered.String,
 	}
 
 	return adminResponse, nil

--- a/db/account.go
+++ b/db/account.go
@@ -203,7 +203,7 @@ type AdminSearchResponse struct {
 	Username        string `json:"username"`
 	DiscordId       string `json:"discordId"`
 	GoogleId        string `json:"googleId"`
-	LastActivity	string `json:"lastLoggedIn"`
+	LastActivity	string `json:"lastLoggedIn"` // TODO: this is currently lastLoggedIn to match server PR #54 with pokerogue PR #4198. We're hotfixing the server with this PR to return lastActivity, but we're not hotfixing the client, so are leaving this as lastLoggedIn so that it still talks to the client properly
 	Registered		string `json:"registered"`
 }
 

--- a/db/account.go
+++ b/db/account.go
@@ -203,15 +203,15 @@ type AdminSearchResponse struct {
 	Username        string `json:"username"`
 	DiscordId       string `json:"discordId"`
 	GoogleId        string `json:"googleId"`
-	LastLoggedIn	string `json:"lastLoggedIn"`
+	LastActivity	string `json:"lastLoggedIn"`
 	Registered		string `json:"registered"`
 }
 
 func FetchAdminDetailsByUsername(dbUsername string) (AdminSearchResponse, error) {
-	var resultUsername, resultDiscordId, resultGoogleId, resultLastLoggedIn, resultRegistered sql.NullString
+	var resultUsername, resultDiscordId, resultGoogleId, resultLastActivity, resultRegistered sql.NullString
 	var adminResponse AdminSearchResponse
 
-	err := handle.QueryRow("SELECT username, discordId, googleId, lastLoggedIn, registered from accounts WHERE username = ?", dbUsername).Scan(&resultUsername, &resultDiscordId, &resultGoogleId, &resultLastLoggedIn, &resultRegistered)
+	err := handle.QueryRow("SELECT username, discordId, googleId, lastActivity, registered from accounts WHERE username = ?", dbUsername).Scan(&resultUsername, &resultDiscordId, &resultGoogleId, &resultLastActivity, &resultRegistered)
 	if err != nil {
 		return adminResponse, err
 	}
@@ -220,7 +220,7 @@ func FetchAdminDetailsByUsername(dbUsername string) (AdminSearchResponse, error)
 		Username:        resultUsername.String,
 		DiscordId:       resultDiscordId.String,
 		GoogleId:        resultGoogleId.String,
-		LastLoggedIn:    resultLastLoggedIn.String,
+		LastActivity:    resultLastActivity.String,
 		Registered:		 resultRegistered.String,
 	}
 


### PR DESCRIPTION
The recent admin panel updates #54 accidentally are grabbing the last logged in date from the server instead of the last activity. This PR aims to fix it.

Here's an image of the live behaviour of the admin panel for a username:

![image](https://github.com/user-attachments/assets/6f2b5477-9529-4b84-b67e-b1682c8b6607)

vs after this PR:

![image](https://github.com/user-attachments/assets/f4113da8-1d1c-4281-b893-f94e463b8fc3)

As you can see, the "Last played" field now shows a different date. We can look at the db for this username:

![image](https://github.com/user-attachments/assets/38ba34a3-e424-45e4-96f6-199a76f2a6b1)

As we can see, this is the right and expected result now

Below is an example of a new user who's made an account and logged in, but hasn't played yet. This is the current behaviour:

![image](https://github.com/user-attachments/assets/87f70125-dcbd-4edb-8b44-ea27db594e61)

And here is the new behaviour:

![image](https://github.com/user-attachments/assets/5a265ee6-c247-4573-bf9d-07ea38f2b367)

As we can see, the last played field is null because they haven't played yet. This is their db record: 

![image](https://github.com/user-attachments/assets/cacedc33-44b4-4401-9289-71d8f209bfc7)

To test this PR, download it and try it out with the admin panel, comparing the values against the db for last activity instead of last logged in date

